### PR TITLE
fix: absolute link and badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
 # AWS IoT Thing, Certificate, and Policy Construct Library
 
+[![NPM](https://img.shields.io/npm/v/@cdklabs/cdk-aws-iot-thing-certificate-policy?label=npm+cdk+v2)](https://www.npmjs.com/package/@cdklabs/cdk-aws-iot-thing-certificate-policy)
+[![PyPI](https://img.shields.io/pypi/v/cdklabs.cdk-aws-iot-thing-certificate-policy?label=pypi+cdk+v2)](https://pypi.org/project/cdklabs.cdk-aws-iot-thing-certificate-policy/)
+[![Maven version](https://img.shields.io/maven-central/v/io.github.cdklabs/cdk-aws-iot-thing-certificate-policy?label=maven+cdk+v2)](https://central.sonatype.com/artifact/io.github.cdklabs/cdk-aws-iot-thing-certificate-policy)
+[![NuGet version](https://img.shields.io/nuget/v/Cdklabs.CdkAwsIotThingCertificatePolicy?label=nuget+cdk+v2)](https://www.nuget.org/packages/Cdklabs.CdkNag)
+[![Go version](https://img.shields.io/github/go-mod/go-version/cdklabs/cdk-aws-iot-thing-certificate-policy?label=go+cdk+v2)](https://github.com/cdklabs/cdk-aws-iot-thing-certificate-policy-go)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/DataDog/datadog-cdk-constructs/blob/main/LICENSE)
+
 ![cdk-constructs: Experimental](https://img.shields.io/badge/cdk--constructs-experimental-important.svg?style=for-the-badge)
 
-[![View on Construct Hub](https://constructs.dev/badge?package=cdk-aws-iot-thing-certificate-policy)](https://constructs.dev/packages/cdk-aws-iot-thing-certificate-policy)
+[![View on Construct Hub](https://constructs.dev/badge?package=@cdklabs/cdk-aws-iot-thing-certificate-policy)](https://constructs.dev/packages/@cdklabs/cdk-aws-iot-thing-certificate-policy)
 
 An [L3 CDK construct](https://docs.aws.amazon.com/cdk/v2/guide/constructs.html#constructs_lib) to create and associate a singular AWS IoT Thing, Certificate, and IoT Policy. The construct also retrieves and returns AWS IoT account specific details such as the AWS IoT data endpoint and the AWS IoT Credential provider endpoint.
 
@@ -19,7 +26,7 @@ The certificate and its private key are stored as AWS Systems Manager Parameter 
 npm install cdk-aws-iot-thing-certificate-policy
 ```
 
-[**API Reference**](doc/api-typescript.md)
+[**API Reference**](https://github.com/cdklabs/cdk-aws-iot-thing-certificate-policy/blob/main/doc/api-typescript.md)
 
 **Example:**
 
@@ -110,7 +117,7 @@ new cdk.CfnOutput(app, "IotEndpoint", {
 pip install cdklabs.cdk-aws-iot-thing-certificate-policy
 ```
 
-[**API Reference**](doc/api-python.md)
+[**API Reference**](https://github.com/cdklabs/cdk-aws-iot-thing-certificate-policy/blob/main/doc/api-python.md)
 
 
 
@@ -189,7 +196,7 @@ cdk.CfnOutput(app, "IotEndpoint", value=foo_thing.data_ats_endpoint_address)
 Coming Soon
 ```
 
-[**API Reference**](doc/api-java.md)
+[**API Reference**](https://github.com/cdklabs/cdk-aws-iot-thing-certificate-policy/blob/main/doc/api-java.md)
 
 **Example:** _Coming soon_
 </details>
@@ -203,7 +210,7 @@ Coming Soon
 dotnet add package Cdklabs.CdkAwsIotThingCertificatePolicy
 ```
 
-[**API Reference**](doc/api-csharp.md)
+[**API Reference**](https://github.com/cdklabs/cdk-aws-iot-thing-certificate-policy/blob/main/doc/api-csharp.md)
 
 **Example:** _coming soon_
 </details>
@@ -217,7 +224,7 @@ dotnet add package Cdklabs.CdkAwsIotThingCertificatePolicy
 Coming soon
 ```
 
-[**API Reference**](doc/api-go.md)
+[**API Reference**](https://github.com/cdklabs/cdk-aws-iot-thing-certificate-policy/blob/main/doc/api-go.md)
 
 **Example:** _coming soon_
 </details>


### PR DESCRIPTION
Fixes:

- Absolute links for APIs back to GitHub - PyPI was using relative links. Still figuring out transpiled example.
- Added badges to capture current version per package manager and direct links
  
  ---
  
  _By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_